### PR TITLE
Create BetterCoin ERC-20 token project scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_PROJECT_ID
+PRIVATE_KEY=0xyourprivatekey
+ETHERSCAN_API_KEY=youretherscanapikey
+REPORT_GAS=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+artifacts/
+cache/
+coverage/
+coverage.json
+typechain/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-# BetterCoin
+# BetterCoin (MBC)
+
+BetterCoin is an ERC-20 compatible token designed for the BetterCoin Minecraft ecosystem. It is built with Hardhat and OpenZeppelin and ships with deployment scripts, verification helpers, unit tests, and integration guidelines.
+
+## Features
+
+- ✅ ERC-20 compliant token with symbol **MBC**
+- ✅ Initial supply of 1,000,000 MBC minted to the deployer (owner)
+- ✅ Owner-gated mint and burn administration functions
+- ✅ Hardhat scripts for local and Sepolia deployment plus Etherscan verification
+- ✅ Unit tests implemented with Hardhat, Ethers, and Chai
+- ✅ Documentation for MetaMask, Remix, and backend integration
+
+## Project Structure
+
+```
+├── contracts
+│   └── BetterCoin.sol           # ERC-20 token implementation
+├── docs
+│   └── USER_GUIDE.md            # Wallet and Remix walkthroughs
+├── examples
+│   └── node-backend.js          # Sample Express balance endpoint
+├── scripts
+│   ├── deploy.js                # Deployment helper
+│   └── verify.js                # Etherscan verification helper
+├── test
+│   └── BetterCoin.js            # Hardhat/Chai unit tests
+├── hardhat.config.js            # Hardhat configuration
+├── package.json
+├── .env.example
+└── README.md
+```
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Copy environment template**
+   ```bash
+   cp .env.example .env
+   ```
+   Populate the `.env` file with your RPC URL, deployer private key, and optional Etherscan API key.
+
+### Useful Scripts
+
+| Command | Description |
+| ------- | ----------- |
+| `npx hardhat compile` | Compile the Solidity contracts. |
+| `npx hardhat test` | Run the unit test suite. |
+| `npx hardhat run scripts/deploy.js --network localhost` | Deploy to a local Hardhat node. |
+| `npx hardhat run scripts/deploy.js --network sepolia` | Deploy to the Sepolia testnet (requires funded deployer account). |
+| `npx hardhat run scripts/verify.js --network sepolia --address <tokenAddress> --owner <ownerAddress>` | Submit verification on Etherscan. |
+| `REPORT_GAS=true npx hardhat test` | Run tests with gas usage reporting. |
+
+## Deployment Workflow
+
+1. Start a local Hardhat node (optional):
+   ```bash
+   npx hardhat node
+   ```
+2. Deploy to the selected network using the `scripts/deploy.js` helper.
+3. Save the printed contract address for subsequent interactions and verification.
+4. (Optional) Verify the contract once deployed on Sepolia:
+   ```bash
+   npx hardhat run scripts/verify.js --network sepolia --address 0xYourToken --owner 0xDeployer
+   ```
+
+## Testing
+
+Run the full test suite with:
+```bash
+npx hardhat test
+```
+
+The tests assert:
+- Initial supply is minted to the deployer.
+- Only the owner can mint or burn tokens.
+- Mint and burn events emit the correct transfer logs.
+
+## MetaMask & Remix Instructions
+
+Detailed wallet setup and Remix interaction instructions are available in [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md).
+
+## Backend Integration Example
+
+A lightweight Node.js/Express endpoint demonstrating how to check a player's token balance is provided in [`examples/node-backend.js`](examples/node-backend.js). Update the RPC URL, contract address, and ABI path as needed for your environment.
+
+## License
+
+This project is released under the MIT License.

--- a/contracts/BetterCoin.sol
+++ b/contracts/BetterCoin.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title BetterCoin
+ * @notice An ERC-20 token for the BetterCoin Minecraft ecosystem.
+ * The contract mints an initial supply to the deployer and allows the owner
+ * to mint or burn tokens in the future for administrative supply management.
+ */
+contract BetterCoin is ERC20, Ownable {
+    uint256 public constant INITIAL_SUPPLY = 1_000_000 * 10 ** 18;
+
+    constructor(address initialOwner) ERC20("BetterCoin", "MBC") Ownable(initialOwner) {
+        _mint(initialOwner, INITIAL_SUPPLY);
+    }
+
+    /**
+     * @notice Mint new tokens to a given address. Only callable by the owner.
+     * @param account The recipient of the newly minted tokens.
+     * @param amount The amount of tokens to mint (in wei units).
+     */
+    function mint(address account, uint256 amount) external onlyOwner {
+        _mint(account, amount);
+    }
+
+    /**
+     * @notice Burn tokens from a given address. Only callable by the owner.
+     * @param account The address whose tokens will be burned.
+     * @param amount The amount of tokens to burn (in wei units).
+     */
+    function burn(address account, uint256 amount) external onlyOwner {
+        _burn(account, amount);
+    }
+}

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,69 @@
+# BetterCoin Wallet & Remix Guide
+
+This guide walks you through interacting with the BetterCoin (MBC) token using MetaMask and Remix. Substitute the placeholder addresses with your deployed contract details.
+
+## MetaMask
+
+### 1. Configure Network
+
+**Local Hardhat**
+1. Open MetaMask and click the network selector.
+2. Choose "Add network manually".
+3. Enter the following values:
+   - **Network Name:** Hardhat Localhost
+   - **RPC URL:** `http://127.0.0.1:8545`
+   - **Chain ID:** `31337`
+   - **Currency Symbol:** `ETH`
+4. Save the configuration and switch to the new network.
+
+**Sepolia Testnet**
+- Sepolia is preconfigured in recent MetaMask builds. If it is not visible, go to *Settings → Advanced* and enable "Show test networks", then select **Sepolia**.
+
+### 2. Import the Deployer Account (Optional)
+
+To use the same account that deployed the contract:
+1. Click the account icon → *Import Account*.
+2. Paste the private key that you used in the `.env` file.
+3. Confirm. **Never import real mainnet keys in a testing environment.**
+
+### 3. Add the BetterCoin Token
+
+1. Navigate to the *Tokens* tab and click **Import tokens**.
+2. Paste your contract address (e.g. `0xYourTokenAddress`).
+3. MetaMask will auto-fill the token symbol (`MBC`) and decimals (`18`).
+4. Click **Add custom token** → **Import tokens**.
+
+You can now see balances, send tokens, and request transfers directly within MetaMask.
+
+### 4. Mint & Burn (Admin Only)
+
+Use Hardhat scripts or Remix to invoke the `mint` and `burn` functions. Only the owner address can execute them. After each transaction, MetaMask will reflect the updated balances.
+
+## Remix
+
+Remix is useful for ad-hoc contract interactions without writing scripts.
+
+1. Open [https://remix.ethereum.org](https://remix.ethereum.org).
+2. In the *File Explorer*, create a new workspace or folder.
+3. Add two files:
+   - `BetterCoin.sol` – copy the contents from [`contracts/BetterCoin.sol`](../contracts/BetterCoin.sol).
+   - `IERC20.sol` – optional if Remix cannot automatically fetch the OpenZeppelin dependency. Alternatively, enable the Remix *"Solidity compiler" → "Enable optimization"* and configure Remix to use the latest compiler with *"Solidity compiler" → "Compiler configuration" → "Enable Hardhat compilation"*.
+4. Navigate to the *Solidity Compiler* tab and compile `BetterCoin.sol` with version `0.8.20`.
+5. Go to the *Deploy & Run Transactions* tab:
+   - **Environment:** Select *Injected Provider - MetaMask* (connects Remix to MetaMask).
+   - **Account:** Choose your deployer/admin wallet.
+   - **Contract:** Choose `BetterCoin`.
+   - **Constructor arguments:** Paste the owner address (typically the MetaMask account).
+6. Click **Deploy** and confirm the transaction in MetaMask. Remix will display the deployed contract under *Deployed Contracts*.
+7. Expand the contract to call functions:
+   - `mint(address,uint256)`: Provide a recipient and amount in wei (e.g. `1000000000000000000` for 1 MBC).
+   - `burn(address,uint256)`: Provide the address and amount to burn (requires prior allowance or balance at the owner).
+   - `balanceOf(address)`: Read wallet balances.
+
+For existing deployments, paste the deployed address in the *At Address* field and click **At Address** to attach Remix to the live contract instance.
+
+## Troubleshooting
+
+- **"execution reverted" during mint/burn:** Ensure your connected MetaMask account matches the contract owner specified at deployment.
+- **Incorrect token symbol/decimals:** Remove and re-import the token with the correct address.
+- **Gas estimation errors:** Confirm the RPC URL is healthy and that the account has sufficient ETH for gas (on Sepolia, use a faucet).

--- a/examples/node-backend.js
+++ b/examples/node-backend.js
@@ -1,0 +1,63 @@
+/**
+ * Sample Express endpoint that returns the BetterCoin balance for a wallet.
+ *
+ * Usage:
+ *   1. npm install express ethers dotenv cors
+ *   2. node node-backend.js
+ */
+const express = require("express");
+const cors = require("cors");
+const { ethers } = require("ethers");
+const path = require("path");
+const fs = require("fs");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+
+const RPC_URL = process.env.SEPOLIA_RPC_URL || "http://127.0.0.1:8545";
+const TOKEN_ADDRESS = process.env.CONTRACT_ADDRESS || "0xYourTokenAddress";
+const ABI_PATH = process.env.TOKEN_ABI_PATH || path.join(__dirname, "../artifacts/contracts/BetterCoin.sol/BetterCoin.json");
+
+if (!fs.existsSync(ABI_PATH)) {
+  console.warn(`ABI file not found at ${ABI_PATH}. Compile the contract first or adjust TOKEN_ABI_PATH.`);
+}
+
+const abi = fs.existsSync(ABI_PATH)
+  ? JSON.parse(fs.readFileSync(ABI_PATH)).abi
+  : [
+      "function balanceOf(address owner) view returns (uint256)",
+      "function decimals() view returns (uint8)",
+      "function symbol() view returns (string)",
+    ];
+
+const provider = new ethers.JsonRpcProvider(RPC_URL);
+const token = new ethers.Contract(TOKEN_ADDRESS, abi, provider);
+
+app.get("/balance/:wallet", async (req, res) => {
+  try {
+    const wallet = req.params.wallet;
+    if (!ethers.isAddress(wallet)) {
+      return res.status(400).json({ error: "Invalid wallet address" });
+    }
+
+    const [rawBalance, decimals, symbol] = await Promise.all([
+      token.balanceOf(wallet),
+      token.decimals(),
+      token.symbol(),
+    ]);
+
+    const formatted = ethers.formatUnits(rawBalance, decimals);
+    res.json({ wallet, balance: formatted, symbol });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Failed to fetch balance" });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`BetterCoin balance API listening on port ${PORT}`);
+});

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,27 @@
+require("dotenv").config();
+require("@nomicfoundation/hardhat-toolbox");
+
+const { SEPOLIA_RPC_URL, PRIVATE_KEY, ETHERSCAN_API_KEY } = process.env;
+
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    hardhat: {},
+    localhost: {
+      url: "http://127.0.0.1:8545",
+    },
+    sepolia: {
+      url: SEPOLIA_RPC_URL || "",
+      accounts: PRIVATE_KEY ? [PRIVATE_KEY] : [],
+    },
+  },
+  etherscan: {
+    apiKey: {
+      sepolia: ETHERSCAN_API_KEY || "",
+    },
+  },
+  gasReporter: {
+    enabled: process.env.REPORT_GAS === "true",
+    currency: "USD",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "bettercoin",
+  "version": "1.0.0",
+  "description": "BetterCoin Hardhat project",
+  "main": "index.js",
+  "scripts": {
+    "clean": "hardhat clean",
+    "compile": "hardhat compile",
+    "test": "hardhat test",
+    "coverage": "hardhat coverage",
+    "deploy:localhost": "hardhat run scripts/deploy.js --network localhost",
+    "deploy:sepolia": "hardhat run scripts/deploy.js --network sepolia",
+    "verify:sepolia": "hardhat run scripts/verify.js --network sepolia"
+  },
+  "keywords": [
+    "hardhat",
+    "solidity",
+    "erc20"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+    "@nomicfoundation/hardhat-ethers": "^3.0.0",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+    "@nomicfoundation/hardhat-toolbox": "^5.0.0",
+    "chai": "^4.3.7",
+    "ethereum-waffle": "^3.4.4",
+    "ethers": "^6.11.1",
+    "hardhat": "^2.22.1",
+    "mocha": "^10.2.0",
+    "solidity-coverage": "^0.8.5"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^4.9.6",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,19 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log("Deploying contracts with account:", deployer.address);
+  console.log("Account balance:", (await deployer.provider.getBalance(deployer.address)).toString());
+
+  const BetterCoin = await ethers.getContractFactory("BetterCoin");
+  const token = await BetterCoin.deploy(deployer.address);
+  await token.waitForDeployment();
+
+  console.log("BetterCoin deployed to:", await token.getAddress());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,41 @@
+const { run } = require("hardhat");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      const key = arg.replace(/^--/, "");
+      const value = args[i + 1];
+      result[key] = value;
+      i += 1;
+    }
+  }
+  return result;
+}
+
+async function main() {
+  const args = parseArgs();
+  const address = args.address || args.token || process.env.CONTRACT_ADDRESS;
+  const owner = args.owner || process.env.OWNER_ADDRESS;
+
+  if (!address || !owner) {
+    throw new Error("Contract address and owner address are required. Use --address <addr> --owner <addr> or set CONTRACT_ADDRESS and OWNER_ADDRESS.");
+  }
+
+  await run("verify:verify", {
+    address,
+    constructorArguments: [owner],
+  });
+
+  console.log(`Verification requested for ${address}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/BetterCoin.js
+++ b/test/BetterCoin.js
@@ -1,0 +1,65 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("BetterCoin", function () {
+  async function deployFixture() {
+    const [owner, otherAccount, thirdAccount] = await ethers.getSigners();
+    const BetterCoin = await ethers.getContractFactory("BetterCoin");
+    const token = await BetterCoin.deploy(owner.address);
+    await token.waitForDeployment();
+    return { token, owner, otherAccount, thirdAccount };
+  }
+
+  describe("Deployment", function () {
+    it("mints the initial supply to the owner", async function () {
+      const { token, owner } = await deployFixture();
+      const decimals = await token.decimals();
+      const expectedSupply = ethers.parseUnits("1000000", decimals);
+      expect(await token.totalSupply()).to.equal(expectedSupply);
+      expect(await token.balanceOf(owner.address)).to.equal(expectedSupply);
+    });
+  });
+
+  describe("Minting", function () {
+    it("allows the owner to mint to another account", async function () {
+      const { token, owner, otherAccount } = await deployFixture();
+      const amount = ethers.parseUnits("2500", await token.decimals());
+      await expect(token.connect(owner).mint(otherAccount.address, amount))
+        .to.emit(token, "Transfer")
+        .withArgs(ethers.ZeroAddress, otherAccount.address, amount);
+      expect(await token.balanceOf(otherAccount.address)).to.equal(amount);
+    });
+
+    it("reverts when a non-owner tries to mint", async function () {
+      const { token, otherAccount, thirdAccount } = await deployFixture();
+      const amount = ethers.parseUnits("1", await token.decimals());
+      await expect(
+        token.connect(otherAccount).mint(thirdAccount.address, amount)
+      )
+        .to.be.revertedWithCustomError(token, "OwnableUnauthorizedAccount")
+        .withArgs(otherAccount.address);
+    });
+  });
+
+  describe("Burning", function () {
+    it("allows the owner to burn from an account", async function () {
+      const { token, owner, otherAccount } = await deployFixture();
+      const decimals = await token.decimals();
+      const mintAmount = ethers.parseUnits("1000", decimals);
+      await token.mint(otherAccount.address, mintAmount);
+      await expect(token.burn(otherAccount.address, mintAmount))
+        .to.emit(token, "Transfer")
+        .withArgs(otherAccount.address, ethers.ZeroAddress, mintAmount);
+      expect(await token.balanceOf(otherAccount.address)).to.equal(0);
+    });
+
+    it("reverts when a non-owner tries to burn", async function () {
+      const { token, owner, otherAccount } = await deployFixture();
+      const decimals = await token.decimals();
+      const burnAmount = ethers.parseUnits("10", decimals);
+      await expect(token.connect(otherAccount).burn(owner.address, burnAmount))
+        .to.be.revertedWithCustomError(token, "OwnableUnauthorizedAccount")
+        .withArgs(otherAccount.address);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the BetterCoin ERC-20 contract with owner-restricted mint and burn logic and initial 1M supply
- configure Hardhat with deployment and verification scripts plus unit tests covering core behaviors
- document wallet/Remix usage and provide a sample Node.js backend balance endpoint

## Testing
- `npm install` *(fails: npm error 403 Forbidden - registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d110a7083269a4831014a625377